### PR TITLE
Remove specific protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "gl-matrix": "^2.4.0",
     "kd.tree": "akshaylive/node-kdt#39bc780704a324393bca68a17cf7bc71be8544c6",
-    "fractional-delay": "git://github.com/Ircam-RnD/fractional-delay#gh-pages"
+    "fractional-delay": "Ircam-RnD/fractional-delay#gh-pages"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi there! The line I changed was causing this error:

```
fatal: remote error: The unauthenticated git protocol on port 9418 is no longer supported
```

Because of this update: https://github.blog/2021-09-01-improving-git-protocol-security-github/

We were getting the error while deploying with Vercel.

Looks like just removing the specific protocol worked!

Thanks!
